### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ If it complains about multiple faces run `main.py` and you should get an output 
 This software is released under the GNU GPL version 3 except for the `haarscascade_frontalface_default.xml` file which is released under the Intel License Agreement For Open Source Computer Vision Library
 
 # Disclaimer
-This software is not intended to diagnosis, cure, or prevent diseases in any way. No warranties are made or implied for its efficacy. It's simply a little program the author wanted and decided to share.
+This software is not intended to diagnose, cure, or prevent diseases in any way. No warranties are made or implied for its efficacy. It's simply a little program the author wanted and decided to share.


### PR DESCRIPTION
'diagnosis' -> 'diagnose'