### PR TITLE
Pedantically change readme to say to explicitly run with python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For all systems additional dependencies need to be installed via:
 
 Tweak `slouchy.ini` to your liking.
 
-Run `python slouchy.py`
+Run `python2 slouchy.py`
 
 Sit upright in front of your webcam.
 


### PR DESCRIPTION
Change README to explicitly say to run it with python2.